### PR TITLE
supporting the construct(constructor, arguments) form

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ Tl;dr
 
 	construct(constructor, arguments);
 
-	// OR
-
-	construct(constructor, [arg1, arg2, arg3]);
-
 Intro
 =====
 

--- a/lib/construct.js
+++ b/lib/construct.js
@@ -2,6 +2,19 @@
 	'use strict';
 
 	/*
+	 * An enhanced version of the typeof operator, allowing us to discriminates object types.
+	 *
+	 * This idea wasborrowed from a blog post from javascriptweblog.wordpress.com:
+	 * https://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/
+	 *
+	 * @param obj- the object which type will be returned
+	 * @return the object 'class' as a string
+	 */
+	function toType(obj) {
+		return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase()
+	}
+
+	/*
 	 * Calls a constructor with an arbitrary number of arguments.
 	 * 
 	 * This idea was borrowed from a StackOverflow answer:
@@ -24,7 +37,15 @@
 		// since arguments isn't a first-class array, we'll use a shim
 		// Big thanks to Felix Geisendörfer for the idea: 
 		// http://debuggable.com/posts/turning-javascript-s-arguments-object-into-an-array:4ac50ef8-3bd0-4a2d-8c2e-535ccbdd56cb
-		return new F(Array.prototype.slice.call(arguments, 1));
+		var args = Array.prototype.slice.call(arguments, 1);
+
+		// if only one argument was passed, and it is an 'arguments' object
+		if (args.length === 1) {
+			if (toType(args[0]) === 'arguments') {
+				args = args[0];
+			}
+		}
+		return new F(args);
 	}
 
 	module.exports = construct;

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	var construct = require('../lib/construct'),
-		temp,
+		test,
 		out;
 
 	function Foo(bar, baz) {
@@ -14,29 +14,41 @@
 		return [this.bar, this.baz].join(' ');
 	};
 
-	temp = construct(Foo, 'Hello', 'World');
+	test = function (temp, desc) {
 
-	if (typeof temp.foobar !== 'function') {
-		console.error('FAIL: prototype not applied, foobar is of type', typeof temp.foobar);
-		process.exit(1);
-	}
+		if (typeof temp.foobar !== 'function') {
+			console.error('FAIL', desc, ': prototype not applied, foobar is of type', typeof temp.foobar);
+			process.exit(1);
+		}
 
-	if (temp.bar !== 'Hello' || temp.baz !== 'World') {
-		console.error('FAIL: internal properties not set correctly; bar:', temp.bar, '; baz:', temp.baz);
-		process.exit(1);
-	}
+		if (temp.bar !== 'Hello' || temp.baz !== 'World') {
+			console.error('FAIL', desc, ': internal properties not set correctly; bar:', temp.bar, '; baz:', temp.baz);
+			process.exit(1);
+		}
 
-	out = temp.foobar();
-	
-	if (out !== 'Hello World') {
-		console.error('FAIL: output not correct:', out);
-		process.exit(1);
-	}
+		out = temp.foobar();
+		
+		if (out !== 'Hello World') {
+			console.error('FAIL', desc, ': output not correct:', out);
+			process.exit(1);
+		}
 
-	if (!(temp instanceof Foo)) {
-		console.error('FAIL: created object not an instance of constructor');
-		process.exit(1);
-	}
+		if (!(temp instanceof Foo)) {
+			console.error('FAIL', desc, ': created object not an instance of constructor');
+			process.exit(1);
+		}
+	};
 
+	// Testing the two possible cases :
+	// - construct(constructor, arg1, arg2, arg3) : more than one additional argument or arg1 isnt an 'arguments' object
+	// - construct(constructor, arguments) : only one additional argument and arg1 is an 'arguments' object
+	test(construct(Foo, 'Hello', 'World'), 'construct(constructor, arg1, arg2, arg3)');
+	test((function () {
+		return construct(Foo, arguments);
+	})('Hello', 'World'), 'construct(constructor, arguments)');
+
+	// We can't discriminate between '[arg1, arg2, arg3]' and 'arg1, arg2, arg3'
+	// Thus [arg1, arg2, arg3] will always be considered as arg1, arg2, arg3 (arg1 beeing an array and arg2, arg3 non-existant in this case.
+	// test(construct(Foo, ['Hello', 'World']), 'construct(constructor, [arg1, arg2, arg3])');
 	console.log('All tests passed!');
 }());


### PR DESCRIPTION
Hi,

the `construct(constructor, arguments)` form didn't work with me, the constructor only received one argument in the form `[arguments]` (that is, an array containing one element : the `arguments` object).

I used a 'hack' inspired by https://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/  in order to discriminate between the two forms (`construct(ctor, arg1, arg2, arg3)` and `construct(ctor, arguments)`).

I also updated the tests and Readme to incorporate the modifications made and remove the `construct(ctor, [arg1, arg2, arg3])` form since this one is not feasible.
